### PR TITLE
[master] fix broken plot urls

### DIFF
--- a/ctplot/web/js/90-web.js
+++ b/ctplot/web/js/90-web.js
@@ -890,7 +890,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     // plot url
                     container.append('<h2>Diesen Plot auf einer Webseite einbinden</h2>');
                     container.append('<p>Der folgende HTML-Code kann benutzt werden um den Plot auf einer Webseite einzubinden.</p>');
-                    plotUrl = $(location).attr('href').replace(/[#?].*/, '') + 'plot?' + query.replace(/a=plot/, 'a=png');
+
+                    // strip stuff like /index.html from current url and append plot url
+                    var currentUrl = window.location.href;
+                    plotUrl = currentUrl.substr(0, currentUrl.lastIndexOf('/')) + '/plot?' + query.replace(/a=plot/, 'a=png');
+
                     p = $('<p>').appendTo(container);
                     $('<textarea id="ploturl">').text('<img src="' + plotUrl + '" />').appendTo(p);
 

--- a/ctplot/web/js/90-web_en.js
+++ b/ctplot/web/js/90-web_en.js
@@ -890,7 +890,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     // plot url
                     container.append('<h2>Include this Diagram into a Website</h2>');
                     container.append('<p>The following HTML-Code can be used to include the Diagram into a Website.</p>');
-                    plotUrl = $(location).attr('href').replace(/[#?].*/, '') + 'plot?' + query.replace(/a=plot/, 'a=png');
+
+                    // strip stuff like /index.html from current url and append plot url
+                    var currentUrl = window.location.href;
+                    plotUrl = currentUrl.substr(0, currentUrl.lastIndexOf('/')) + '/plot?' + query.replace(/a=plot/, 'a=png');
+
                     p = $('<p>').appendTo(container);
                     $('<textarea id="ploturl">').text('<img src="' + plotUrl + '" />').appendTo(p);
 


### PR DESCRIPTION
This fixes the display bug of saved diagrams, where only the frame is shown. The generated plot urls where malformed.

The fix only applies to newly saved diagrams and does not fix malformed plot urls already saved in the session.